### PR TITLE
LICENSEファイルの追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+LICENSE TERM
+
+Copyright (c) 2024 CARTA HOLDINGS
+
+This work is a derivative of "Structure and Interpretation of Computer Programs" by Harold Abelson and Gerald Jay Sussman with Julie Sussman, which is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+The original work is available at https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/6515/sicp.zip/full-text/book/book.html.
+
+The materials in this repository developed by CARTA HOLDINGS are also licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (http://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
### 概要
このリポジトリを Public にするにあたって、LICENSE ファイルを作成した。

### やったこと

CC BY-SA 4.0 を適用し、その attribute を記述。

以下は gemini に聞いてみた内容で以下を参考に記入。

```3. LICENSEファイルへの具体的な記載（CC BY-SA 4.0の場合）

もしリポジトリの主要な内容がSICPの派生物であり、CC BY-SA 4.0を適用する場合、LICENSE ファイルには以下のような情報を記載します。

あなたのリポジトリの著作権表示:
例: Copyright (c) [Year] [Your Company Name/Contributors]
あなたのリポジトリのライセンス宣言:
あなたのリポジトリ（またはその派生物部分）がCC BY-SA 4.0でライセンスされることを明記します。
CC BY-SA 4.0のライセンス条文へのリンク（http://creativecommons.org/licenses/by-sa/4.0/）を記載します。
元の作品 (SICP) へのAttribution (表示): CC BY-SA 4.0が要求する表示です。
タイトル: Structure and Interpretation of Computer Programs
著作者: Harold Abelson and Gerald Jay Sussman with Julie Sussman (もしオンライン版で特定の著作者表記があればそれに従います)
原典へのリンク: SICPの公式HTML版など、参照した場所へのリンク
ライセンス: Creative Commons Attribution-ShareAlike 4.0 International License
ライセンスへのリンク: http://creativecommons.org/licenses/by-sa/4.0/
変更を加えた場合はその旨を記載（例: 「このリポジトリの資料は、SICPの該当箇所を元に解説を加えています」など）。
記載例 (LICENSEファイルに追記するAttribution部分):

This work is a derivative of "Structure and Interpretation of Computer Programs" by Harold Abelson and Gerald Jay Sussman with Julie Sussman, which is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
The original work is available at [SICPのHTML版など、原典へのURLを記載].

The materials in this repository developed by [Your Company Name/Contributors] are also licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (http://creativecommons.org/licenses/by-sa/4.0/).

---

[ここにCC BY-SA 4.0のライセンス条文の全文または公式への明確なリンクを記載。通常はライセンス名とリンクで十分な場合が多いですが、確認してください。]

Copyright (c) [Year] [Your Company Name/Contributors]
```

### 参考

他の CARTA HOLDINGS の Public リポジトリの LICENSE の例

* https://github.com/voyagegroup/apns-proxy-server/blob/master/LICENSE.txt
* https://github.com/voyagegroup/make-advent-calendar-2017-to-2019/blob/master/LICENSE
* https://github.com/voyagegroup/ingred-ui/blob/master/LICENSE

流石に CC BY-SA 4.0 はなかった